### PR TITLE
feat(uploader): deferred uploads on create + grouped `listAll` view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
+- **Deferred uploads on create**: You can now queue files before the target model exists and attach them after save by dispatching the `media:attach` event. The uploader accepts `model="post"` (no `id`) on create screens, holds the queue + per-file meta, and attaches once you dispatch. Emits `media-attached` when done.
+- **`list-all` view**: Set `:list-all="true"` to show **all collections** for the current model in a single list, grouped by collection name. Items remain fully editable (caption/description/order).
+- **Tailwind dark mode docs/snippets**: Added guidance and examples for enabling global light/dark mode with the Tailwind theme.
 
 ### Changed
+- Graceful “no target yet” behavior on create screens:
+    - `nextOrder()` now derives order from the local queue if the model isn’t saved yet.
+    - `uploadFiles()` **queues** when there’s no target (instead of erroring) and flashes: _“Files queued. They will be attached after you save.”_
 
 ### Fixed
-
+- N/A
 
 ---
 ## [v0.2.0] — 2025-09-01
@@ -95,5 +100,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/codebyray/livewire-media-uploader/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/codebyray/livewire-media-uploader/compare/v0.2.0...HEAD
 [v0.1.0]: https://github.com/codebyray/livewire-media-uploader/releases/tag/v0.1.0

--- a/resources/views/themes/bootstrap/media-uploader.blade.php
+++ b/resources/views/themes/bootstrap/media-uploader.blade.php
@@ -256,144 +256,242 @@
                     <p class="small text-muted mb-0">No gallery images yet.</p>
                 </div>
             @else
-                <ul class="list-group list-group-flush">
-                    @foreach ($items as $m)
-                        @php
-                            $id = (int) $m['id'];
-                            $isEditing = isset($editing[$id]);
-                            $linkText = $m['caption'] ?: ($m['name'] ?: ($m['original_name'] ?? $m['file_name']));
-                        @endphp
+                @if (count($items) === 0)
+                    <div class="p-3">
+                        <p class="small text-muted mb-0">No gallery images yet.</p>
+                    </div>
+                @else
+                    @if ($listAll)
+                        {{-- Grouped by collection --}}
+                        @foreach ($groups as $collectionName => $collectionItems)
+                            <div class="px-3 py-2 bg-light border-bottom">
+                                <div class="small fw-semibold text-body text-uppercase">{{ $collectionName }}</div>
+                            </div>
 
-                        <li class="list-group-item p-3 d-flex gap-3 align-items-start">
-                            {{-- Thumbnail / icon --}}
-                            @if(!empty($m['thumb']))
-                                <img src="{{ $m['thumb'] }}" alt="" class="rounded border" style="width:64px;height:64px;object-fit:cover;">
-                            @else
-                                <div class="rounded border d-grid text-muted align-items-center justify-content-center" style="width:64px;height:64px;place-items:center;">
-                                    <svg viewBox="0 0 24 24" style="width:28px;height:28px" fill="none" stroke="currentColor" stroke-width="1.5">
-                                        <path d="M7 3h6l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/>
-                                        <path d="M13 3v5h5"/>
-                                    </svg>
-                                </div>
-                            @endif
-
-                            {{-- Content --}}
-                            <div class="flex-grow-1 min-w-0">
-                                @if (! $isEditing)
+                            <ul class="list-group list-group-flush">
+                                @foreach ($collectionItems as $m)
                                     @php
-                                        $isImage = \Illuminate\Support\Str::startsWith($m['mime'] ?? '', 'image/');
+                                        $id = (int) $m['id'];
+                                        $isEditing = isset($editing[$id]);
+                                        $linkText = $m['caption'] ?: ($m['name'] ?: ($m['original_name'] ?? $m['file_name']));
                                     @endphp
 
-                                    <div class="fw-semibold text-truncate">
-                                        @if ($isImage)
-                                            <button
-                                                type="button"
-                                                @click="openPreview(@js($m['url']), @js($linkText))"
-                                                class="btn btn-link p-0 align-baseline"
-                                            >
-                                                {{ $linkText }}
-                                            </button>
+                                    {{-- Paste your existing <li>...</li> markup here, unchanged, using $m --}}
+                                    <li class="list-group-item p-3 d-flex gap-3 align-items-start">
+                                        {{-- Thumbnail / icon --}}
+                                        @if(!empty($m['thumb']))
+                                            <img src="{{ $m['thumb'] }}" alt="" class="rounded border" style="width:64px;height:64px;object-fit:cover;">
                                         @else
-                                            <a
-                                                href="{{ $m['url'] }}"
-                                                target="_blank"
-                                                class="link-primary text-decoration-none"
-                                            >
-                                                {{ $linkText }}
-                                            </a>
-                                        @endif
-                                    </div>
-                                    @if(!empty($m['description']))
-                                        <div class="small text-muted text-truncate">{{ $m['description'] }}</div>
-                                    @endif
-                                    <div class="small text-muted">{{ number_format(($m['size'] ?? 0)/1024, 1) }} KB</div>
-                                @else
-                                    <div class="row g-2">
-                                        <div class="col-12 col-md-6">
-                                            <div class="form-label small mb-1">Caption</div>
-                                            <input
-                                                type="text"
-                                                wire:model.defer="editing.{{ $id }}.caption"
-                                                placeholder="Optional caption"
-                                                class="form-control form-control-sm"
-                                            />
-                                            @error('editing.'.$id.'.caption')
-                                            <div class="form-text text-danger">{{ $message }}</div>
-                                            @enderror
-                                        </div>
-
-                                        <div class="col-12 col-md-6">
-                                            <div class="form-label small mb-1">Description</div>
-                                            <input
-                                                type="text"
-                                                wire:model.defer="editing.{{ $id }}.description"
-                                                placeholder="Optional description"
-                                                class="form-control form-control-sm"
-                                            />
-                                            @error('editing.'.$id.'.description')
-                                            <div class="form-text text-danger">{{ $message }}</div>
-                                            @enderror
-                                        </div>
-
-                                        <div class="col-12 col-md-3">
-                                            <div class="form-label small mb-1">Order</div>
-                                            <div style="max-width: 80px;">
-                                                <input
-                                                    type="number" min="1" step="1"
-                                                    wire:model.defer="editing.{{ $id }}.order"
-                                                    class="form-control form-control-sm text-center"
-                                                />
+                                            <div class="rounded border d-grid text-muted align-items-center justify-content-center" style="width:64px;height:64px;place-items:center;">
+                                                <svg viewBox="0 0 24 24" style="width:28px;height:28px" fill="none" stroke="currentColor" stroke-width="1.5">
+                                                    <path d="M7 3h6l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/>
+                                                    <path d="M13 3v5h5"/>
+                                                </svg>
                                             </div>
-                                            @error('editing.'.$id.'.order')
-                                            <div class="form-text text-danger">{{ $message }}</div>
-                                            @enderror
+                                        @endif
+
+                                        {{-- Content (unchanged) --}}
+                                        <div class="flex-grow-1 min-w-0">
+                                            @php $isImage = \Illuminate\Support\Str::startsWith($m['mime'] ?? '', 'image/'); @endphp
+                                            @if (! $isEditing)
+                                                <div class="fw-semibold text-truncate">
+                                                    @if ($isImage)
+                                                        <button type="button" @click="openPreview(@js($m['url']), @js($linkText))" class="btn btn-link p-0 align-baseline">
+                                                            {{ $linkText }}
+                                                        </button>
+                                                    @else
+                                                        <a href="{{ $m['url'] }}" target="_blank" class="link-primary text-decoration-none">
+                                                            {{ $linkText }}
+                                                        </a>
+                                                    @endif
+                                                </div>
+                                                @if(!empty($m['description']))
+                                                    <div class="small text-muted text-truncate">{{ $m['description'] }}</div>
+                                                @endif
+                                                <div class="small text-muted">
+                                                    {{ number_format(($m['size'] ?? 0)/1024, 1) }} KB
+                                                    <span class="mx-2">•</span>
+                                                    <span class="text-uppercase">{{ $m['collection'] }}</span>
+                                                </div>
+                                            @else
+                                                {{-- your existing edit form for caption/description/order --}}
+                                                <div class="row g-2">
+                                                    <div class="col-12 col-md-6">
+                                                        <div class="form-label small mb-1">Caption</div>
+                                                        <input type="text" wire:model.defer="editing.{{ $id }}.caption" class="form-control form-control-sm" />
+                                                        @error('editing.'.$id.'.caption') <div class="form-text text-danger">{{ $message }}</div> @enderror
+                                                    </div>
+                                                    <div class="col-12 col-md-6">
+                                                        <div class="form-label small mb-1">Description</div>
+                                                        <input type="text" wire:model.defer="editing.{{ $id }}.description" class="form-control form-control-sm" />
+                                                        @error('editing.'.$id.'.description') <div class="form-text text-danger">{{ $message }}</div> @enderror
+                                                    </div>
+                                                    <div class="col-12 col-md-3">
+                                                        <div class="form-label small mb-1">Order</div>
+                                                        <div style="max-width: 80px;">
+                                                            <input type="number" min="1" step="1" wire:model.defer="editing.{{ $id }}.order" class="form-control form-control-sm text-center" />
+                                                        </div>
+                                                        @error('editing.'.$id.'.order') <div class="form-text text-danger">{{ $message }}</div> @enderror
+                                                    </div>
+                                                </div>
+                                            @endif
                                         </div>
+
+                                        <div class="d-flex gap-2 align-self-stretch align-items-center">
+                                            @if (! $isEditing)
+                                                <button type="button" wire:click="startEdit({{ $id }})" class="btn btn-outline-secondary btn-sm">Edit</button>
+                                                <button type="button" wire:click="confirmDelete({{ $id }})" class="btn btn-outline-danger btn-sm">Delete</button>
+                                            @else
+                                                <div class="d-flex gap-2 mt-2 mt-md-0">
+                                                    <button type="button" wire:click="saveEdit({{ $id }})" class="btn btn-outline-primary btn-sm">Save</button>
+                                                    <button type="button" wire:click="cancelEdit({{ $id }})" class="btn btn-outline-secondary btn-sm">Cancel</button>
+                                                </div>
+                                            @endif
+                                        </div>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        @endforeach
+                    @else
+                        <ul class="list-group list-group-flush">
+                        @foreach ($items as $m)
+                            @php
+                                $id = (int) $m['id'];
+                                $isEditing = isset($editing[$id]);
+                                $linkText = $m['caption'] ?: ($m['name'] ?: ($m['original_name'] ?? $m['file_name']));
+                            @endphp
+
+                            <li class="list-group-item p-3 d-flex gap-3 align-items-start">
+                                {{-- Thumbnail / icon --}}
+                                @if(!empty($m['thumb']))
+                                    <img src="{{ $m['thumb'] }}" alt="" class="rounded border" style="width:64px;height:64px;object-fit:cover;">
+                                @else
+                                    <div class="rounded border d-grid text-muted align-items-center justify-content-center" style="width:64px;height:64px;place-items:center;">
+                                        <svg viewBox="0 0 24 24" style="width:28px;height:28px" fill="none" stroke="currentColor" stroke-width="1.5">
+                                            <path d="M7 3h6l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/>
+                                            <path d="M13 3v5h5"/>
+                                        </svg>
                                     </div>
                                 @endif
-                            </div>
 
-                            <div class="d-flex gap-2 align-self-stretch align-items-center">
-                                @if (! $isEditing)
-                                    <button
-                                        type="button"
-                                        wire:click="startEdit({{ $id }})"
-                                        class="btn btn-outline-secondary btn-sm"
-                                    >
-                                        Edit
-                                    </button>
-                                    <button
-                                        type="button"
-                                        wire:click="confirmDelete({{ $id }})"
-                                        wire:loading.attr="disabled"
-                                        class="btn btn-outline-danger btn-sm"
-                                    >
-                                        Delete
-                                    </button>
-                                @else
-                                    <div class="d-flex gap-2 mt-2 mt-md-0">
+                                {{-- Content --}}
+                                <div class="flex-grow-1 min-w-0">
+                                    @if (! $isEditing)
+                                        @php
+                                            $isImage = \Illuminate\Support\Str::startsWith($m['mime'] ?? '', 'image/');
+                                        @endphp
+
+                                        <div class="fw-semibold text-truncate">
+                                            @if ($isImage)
+                                                <button
+                                                    type="button"
+                                                    @click="openPreview(@js($m['url']), @js($linkText))"
+                                                    class="btn btn-link p-0 align-baseline"
+                                                >
+                                                    {{ $linkText }}
+                                                </button>
+                                            @else
+                                                <a
+                                                    href="{{ $m['url'] }}"
+                                                    target="_blank"
+                                                    class="link-primary text-decoration-none"
+                                                >
+                                                    {{ $linkText }}
+                                                </a>
+                                            @endif
+                                        </div>
+                                        @if(!empty($m['description']))
+                                            <div class="small text-muted text-truncate">{{ $m['description'] }}</div>
+                                        @endif
+                                        <div class="small text-muted">{{ number_format(($m['size'] ?? 0)/1024, 1) }} KB</div>
+                                    @else
+                                        <div class="row g-2">
+                                            <div class="col-12 col-md-6">
+                                                <div class="form-label small mb-1">Caption</div>
+                                                <input
+                                                    type="text"
+                                                    wire:model.defer="editing.{{ $id }}.caption"
+                                                    placeholder="Optional caption"
+                                                    class="form-control form-control-sm"
+                                                />
+                                                @error('editing.'.$id.'.caption')
+                                                <div class="form-text text-danger">{{ $message }}</div>
+                                                @enderror
+                                            </div>
+
+                                            <div class="col-12 col-md-6">
+                                                <div class="form-label small mb-1">Description</div>
+                                                <input
+                                                    type="text"
+                                                    wire:model.defer="editing.{{ $id }}.description"
+                                                    placeholder="Optional description"
+                                                    class="form-control form-control-sm"
+                                                />
+                                                @error('editing.'.$id.'.description')
+                                                <div class="form-text text-danger">{{ $message }}</div>
+                                                @enderror
+                                            </div>
+
+                                            <div class="col-12 col-md-3">
+                                                <div class="form-label small mb-1">Order</div>
+                                                <div style="max-width: 80px;">
+                                                    <input
+                                                        type="number" min="1" step="1"
+                                                        wire:model.defer="editing.{{ $id }}.order"
+                                                        class="form-control form-control-sm text-center"
+                                                    />
+                                                </div>
+                                                @error('editing.'.$id.'.order')
+                                                <div class="form-text text-danger">{{ $message }}</div>
+                                                @enderror
+                                            </div>
+                                        </div>
+                                    @endif
+                                </div>
+
+                                <div class="d-flex gap-2 align-self-stretch align-items-center">
+                                    @if (! $isEditing)
                                         <button
                                             type="button"
-                                            wire:click="saveEdit({{ $id }})"
-                                            wire:loading.attr="disabled"
-                                            class="btn btn-outline-primary btn-sm"
-                                        >
-                                            Save
-                                        </button>
-                                        <button
-                                            type="button"
-                                            wire:click="cancelEdit({{ $id }})"
+                                            wire:click="startEdit({{ $id }})"
                                             class="btn btn-outline-secondary btn-sm"
                                         >
-                                            Cancel
+                                            Edit
                                         </button>
-                                    </div>
-                                @endif
-                            </div>
-                        </li>
-                    @endforeach
-                </ul>
+                                        <button
+                                            type="button"
+                                            wire:click="confirmDelete({{ $id }})"
+                                            wire:loading.attr="disabled"
+                                            class="btn btn-outline-danger btn-sm"
+                                        >
+                                            Delete
+                                        </button>
+                                    @else
+                                        <div class="d-flex gap-2 mt-2 mt-md-0">
+                                            <button
+                                                type="button"
+                                                wire:click="saveEdit({{ $id }})"
+                                                wire:loading.attr="disabled"
+                                                class="btn btn-outline-primary btn-sm"
+                                            >
+                                                Save
+                                            </button>
+                                            <button
+                                                type="button"
+                                                wire:click="cancelEdit({{ $id }})"
+                                                class="btn btn-outline-secondary btn-sm"
+                                            >
+                                                Cancel
+                                            </button>
+                                        </div>
+                                    @endif
+                                </div>
+                            </li>
+                            @endforeach
+                            </ul>
+                    @endif
+                @endif
 
-                <!-- Image Preview Overlay -->
                 <div
                     x-cloak
                     x-show="preview.open"

--- a/resources/views/themes/tailwind/media-uploader.blade.php
+++ b/resources/views/themes/tailwind/media-uploader.blade.php
@@ -283,161 +283,332 @@
                     <p class="text-sm text-neutral-500 dark:text-neutral-400 mb-0">No gallery images yet.</p>
                 </div>
             @else
-                <ul class="divide-y divide-neutral-200 dark:divide-neutral-800">
-                    @foreach ($items as $m)
-                        @php
-                            $id = (int) $m['id'];
-                            $isEditing = isset($editing[$id]);
-                            $linkText = $m['caption'] ?: ($m['name'] ?: ($m['original_name'] ?? $m['file_name']));
-                        @endphp
+                @if (!empty($listAll) && $listAll && !empty($groups))
+                    {{-- GROUPED BY COLLECTION --}}
+                    @foreach ($groups as $collectionName => $collectionItems)
+                        {{-- Group header --}}
+                        <div class="px-4 py-2 bg-neutral-50 dark:bg-neutral-800/50 border-b border-neutral-200 dark:border-neutral-800">
+                            <div class="text-[11px] font-semibold tracking-wide uppercase text-neutral-500 dark:text-neutral-400">
+                                {{ $collectionName }}
+                            </div>
+                        </div>
 
-                        <li class="p-3 flex content-center gap-3">
-                            {{-- Thumbnail / icon --}}
-                            @if(!empty($m['thumb']))
-                                <img src="{{ $m['thumb'] }}" alt="" class="rounded-md object-cover w-16 h-16 border border-neutral-200 dark:border-neutral-700">
-                            @else
-                                <div class="rounded-md w-16 h-16 grid place-items-center border border-neutral-200 dark:border-neutral-700 text-neutral-400 dark:text-neutral-500">
-                                    <svg viewBox="0 0 24 24" class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="1.5">
-                                        <path d="M7 3h6l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/>
-                                        <path d="M13 3v5h5"/>
-                                    </svg>
-                                </div>
-                            @endif
+                        <ul class="divide-y divide-neutral-200 dark:divide-neutral-800">
+                            @foreach ($collectionItems as $m)
+                                @php
+                                    $id = (int) $m['id'];
+                                    $isEditing = isset($editing[$id]);
+                                    $linkText = $m['caption'] ?: ($m['name'] ?: ($m['original_name'] ?? $m['file_name']));
+                                    $isImage = \Illuminate\Support\Str::startsWith($m['mime'] ?? '', 'image/');
+                                @endphp
 
-                            {{-- Content --}}
-                            <div class="flex-1 min-w-0 max-w-full">
-                                @if (! $isEditing)
-                                    @php
-                                        $isImage = \Illuminate\Support\Str::startsWith($m['mime'] ?? '', 'image/');
-                                    @endphp
+                                <li class="p-3 flex content-center gap-3">
+                                    {{-- Thumbnail / icon --}}
+                                    @if(!empty($m['thumb']))
+                                        <img src="{{ $m['thumb'] }}" alt="" class="rounded-md object-cover w-16 h-16 border border-neutral-200 dark:border-neutral-700">
+                                    @else
+                                        <div class="rounded-md w-16 h-16 grid place-items-center border border-neutral-200 dark:border-neutral-700 text-neutral-400 dark:text-neutral-500">
+                                            <svg viewBox="0 0 24 24" class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="1.5">
+                                                <path d="M7 3h6l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/>
+                                                <path d="M13 3v5h5"/>
+                                            </svg>
+                                        </div>
+                                    @endif
 
-                                    <div class="font-semibold truncate">
-                                        @if ($isImage)
-                                            <button
-                                                type="button"
-                                                @click="openPreview(@js($m['url']), @js($linkText))"
-                                                class="cursor-pointer text-emerald-700 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
-                                            >
-                                                {{ $linkText }}
-                                            </button>
+                                    {{-- Content --}}
+                                    <div class="flex-1 min-w-0 max-w-full">
+                                        @if (! $isEditing)
+                                            <div class="font-semibold truncate">
+                                                @if ($isImage)
+                                                    <button
+                                                        type="button"
+                                                        @click="openPreview(@js($m['url']), @js($linkText))"
+                                                        class="cursor-pointer text-emerald-700 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
+                                                    >
+                                                        {{ $linkText }}
+                                                    </button>
+                                                @else
+                                                    <a
+                                                        href="{{ $m['url'] }}"
+                                                        target="_blank"
+                                                        class="cursor-pointer text-emerald-700 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
+                                                    >
+                                                        {{ $linkText }}
+                                                    </a>
+                                                @endif
+                                            </div>
+
+                                            {{-- Optional description --}}
+                                            @if(!empty($m['description']))
+                                                <div class="text-sm text-neutral-500 dark:text-neutral-400 truncate">{{ $m['description'] }}</div>
+                                            @endif
+
+                                            {{-- Size + collection name meta --}}
+                                            <div class="text-xs text-neutral-500 dark:text-neutral-400">
+                                                {{ number_format(($m['size'] ?? 0)/1024, 1) }} KB
+                                                @if(!empty($m['collection']))
+                                                    <span class="mx-2">•</span>
+                                                    <span class="uppercase">{{ $m['collection'] }}</span>
+                                                @endif
+                                            </div>
                                         @else
-                                            <a
-                                                href="{{ $m['url'] }}"
-                                                target="_blank"
-                                                class="cursor-pointer text-emerald-700 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
-                                            >
-                                                {{ $linkText }}
-                                            </a>
+                                            <div class="grid grid-cols-1 md:[grid-template-columns:1fr_2fr_auto] gap-2 max-w-full">
+                                                <div>
+                                                    <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Caption</div>
+                                                    <input
+                                                        type="text"
+                                                        wire:model.defer="editing.{{ $id }}.caption"
+                                                        placeholder="Optional caption"
+                                                        class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm
+                                                   text-neutral-900 placeholder-neutral-400
+                                                   focus:outline-none focus:ring-2 focus:ring-sky-500
+                                                   dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+                                                    />
+                                                    @error('editing.'.$id.'.caption')
+                                                    <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
+                                                    @enderror
+                                                </div>
+
+                                                <div>
+                                                    <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Description</div>
+                                                    <input
+                                                        type="text"
+                                                        wire:model.defer="editing.{{ $id }}.description"
+                                                        placeholder="Optional description"
+                                                        class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm
+                                                   text-neutral-900 placeholder-neutral-400
+                                                   focus:outline-none focus:ring-2 focus:ring-sky-500
+                                                   dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+                                                    />
+                                                    @error('editing.'.$id.'.description')
+                                                    <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
+                                                    @enderror
+                                                </div>
+
+                                                <div>
+                                                    <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Order</div>
+                                                    <div class="w-20">
+                                                        <input
+                                                            type="number" min="1" step="1"
+                                                            wire:model.defer="editing.{{ $id }}.order"
+                                                            class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-center
+                                                       text-neutral-900 placeholder-neutral-400
+                                                       focus:outline-none focus:ring-2 focus:ring-sky-500
+                                                       dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+                                                        />
+                                                    </div>
+                                                    @error('editing.'.$id.'.order')
+                                                    <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
+                                                    @enderror
+                                                </div>
+                                            </div>
                                         @endif
                                     </div>
-                                    @if(!empty($m['description']))
-                                        <div class="text-sm text-neutral-500 dark:text-neutral-400 truncate">{{ $m['description'] }}</div>
-                                    @endif
-                                    <div class="text-xs text-neutral-500 dark:text-neutral-400">{{ number_format(($m['size'] ?? 0)/1024, 1) }} KB</div>
-                                @else
-                                    <div class="grid grid-cols-1 md:[grid-template-columns:1fr_2fr_auto] gap-2 max-w-full">
-                                        <div>
-                                            <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Caption</div>
-                                            <input
-                                                type="text"
-                                                wire:model.defer="editing.{{ $id }}.caption"
-                                                placeholder="Optional caption"
-                                                class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm
-                                                       text-neutral-900 placeholder-neutral-400
-                                                       focus:outline-none focus:ring-2 focus:ring-sky-500
-                                                       dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
-                                            />
-                                            @error('editing.'.$id.'.caption')
-                                            <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
-                                            @enderror
-                                        </div>
 
-                                        <div>
-                                            <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Description</div>
-                                            <input
-                                                type="text"
-                                                wire:model.defer="editing.{{ $id }}.description"
-                                                placeholder="Optional description"
-                                                class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm
-                                                       text-neutral-900 placeholder-neutral-400
-                                                       focus:outline-none focus:ring-2 focus:ring-sky-500
-                                                       dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
-                                            />
-                                            @error('editing.'.$id.'.description')
-                                            <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-
-                                        <div>
-                                            <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Order</div>
-                                            <div class="w-20">
-                                                <input
-                                                    type="number" min="1" step="1"
-                                                    wire:model.defer="editing.{{ $id }}.order"
-                                                    class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-center
-                                                           text-neutral-900 placeholder-neutral-400
-                                                           focus:outline-none focus:ring-2 focus:ring-sky-500
-                                                           dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
-                                                />
-                                            </div>
-                                            @error('editing.'.$id.'.order')
-                                            <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
-                                            @enderror
-                                        </div>
-                                    </div>
-                                @endif
-                            </div>
-
-                            <div class="flex gap-2 self-stretch md:items-center">
-                                @if (! $isEditing)
-                                    <button
-                                        type="button"
-                                        wire:click="startEdit({{ $id }})"
-                                        class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                    <div class="flex gap-2 self-stretch md:items-center">
+                                        @if (! $isEditing)
+                                            <button
+                                                type="button"
+                                                wire:click="startEdit({{ $id }})"
+                                                class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                           hover:bg-neutral-100 text-neutral-700
+                                           dark:text-neutral-200 dark:hover:bg-neutral-800"
+                                            >
+                                                Edit
+                                            </button>
+                                            <button
+                                                type="button"
+                                                wire:click="confirmDelete({{ $id }})"
+                                                wire:loading.attr="disabled"
+                                                class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                           border border-red-500 text-red-600 hover:bg-red-50
+                                           dark:border-red-600 dark:text-red-400 dark:hover:bg-red-900/20"
+                                            >
+                                                Delete
+                                            </button>
+                                        @else
+                                            <div class="flex items-center gap-2 self-stretch mt-4">
+                                                <button
+                                                    type="button"
+                                                    wire:click="saveEdit({{ $id }})"
+                                                    wire:loading.attr="disabled"
+                                                    class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                               border border-sky-500 text-sky-600 hover:bg-sky-50
+                                               dark:border-sky-600 dark:text-sky-400 dark:hover:bg-sky-900/20"
+                                                >
+                                                    Save
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    wire:click="cancelEdit({{ $id }})"
+                                                    class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
                                                hover:bg-neutral-100 text-neutral-700
                                                dark:text-neutral-200 dark:hover:bg-neutral-800"
-                                    >
-                                        Edit
-                                    </button>
-                                    <button
-                                        type="button"
-                                        wire:click="confirmDelete({{ $id }})"
-                                        wire:loading.attr="disabled"
-                                        class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
-                                               border border-red-500 text-red-600 hover:bg-red-50
-                                               dark:border-red-600 dark:text-red-400 dark:hover:bg-red-900/20"
-                                    >
-                                        Delete
-                                    </button>
+                                                >
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        @endif
+                                    </div>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endforeach
+                @else
+                    {{-- SINGLE COLLECTION (original rendering) --}}
+                    <ul class="divide-y divide-neutral-200 dark:divide-neutral-800">
+                        @foreach ($items as $m)
+                            @php
+                                $id = (int) $m['id'];
+                                $isEditing = isset($editing[$id]);
+                                $linkText = $m['caption'] ?: ($m['name'] ?: ($m['original_name'] ?? $m['file_name']));
+                                $isImage = \Illuminate\Support\Str::startsWith($m['mime'] ?? '', 'image/');
+                            @endphp
+
+                            <li class="p-3 flex content-center gap-3">
+                                {{-- Thumbnail / icon --}}
+                                @if(!empty($m['thumb']))
+                                    <img src="{{ $m['thumb'] }}" alt="" class="rounded-md object-cover w-16 h-16 border border-neutral-200 dark:border-neutral-700">
                                 @else
-                                    <div class="flex items-center gap-2 self-stretch mt-4">
-                                        <button
-                                            type="button"
-                                            wire:click="saveEdit({{ $id }})"
-                                            wire:loading.attr="disabled"
-                                            class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
-                                                   border border-sky-500 text-sky-600 hover:bg-sky-50
-                                                   dark:border-sky-600 dark:text-sky-400 dark:hover:bg-sky-900/20"
-                                        >
-                                            Save
-                                        </button>
-                                        <button
-                                            type="button"
-                                            wire:click="cancelEdit({{ $id }})"
-                                            class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
-                                                   hover:bg-neutral-100 text-neutral-700
-                                                   dark:text-neutral-200 dark:hover:bg-neutral-800"
-                                        >
-                                            Cancel
-                                        </button>
+                                    <div class="rounded-md w-16 h-16 grid place-items-center border border-neutral-200 dark:border-neutral-700 text-neutral-400 dark:text-neutral-500">
+                                        <svg viewBox="0 0 24 24" class="w-7 h-7" fill="none" stroke="currentColor" stroke-width="1.5">
+                                            <path d="M7 3h6l5 5v13a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z"/>
+                                            <path d="M13 3v5h5"/>
+                                        </svg>
                                     </div>
                                 @endif
-                            </div>
-                        </li>
-                    @endforeach
-                </ul>
 
-                <!-- Image Preview Overlay -->
+                                {{-- Content --}}
+                                <div class="flex-1 min-w-0 max-w-full">
+                                    @if (! $isEditing)
+                                        <div class="font-semibold truncate">
+                                            @if ($isImage)
+                                                <button
+                                                    type="button"
+                                                    @click="openPreview(@js($m['url']), @js($linkText))"
+                                                    class="cursor-pointer text-emerald-700 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
+                                                >
+                                                    {{ $linkText }}
+                                                </button>
+                                            @else
+                                                <a
+                                                    href="{{ $m['url'] }}"
+                                                    target="_blank"
+                                                    class="cursor-pointer text-emerald-700 hover:text-emerald-800 dark:text-emerald-300 dark:hover:text-emerald-200"
+                                                >
+                                                    {{ $linkText }}
+                                                </a>
+                                            @endif
+                                        </div>
+                                        @if(!empty($m['description']))
+                                            <div class="text-sm text-neutral-500 dark:text-neutral-400 truncate">{{ $m['description'] }}</div>
+                                        @endif
+                                        <div class="text-xs text-neutral-500 dark:text-neutral-400">{{ number_format(($m['size'] ?? 0)/1024, 1) }} KB</div>
+                                    @else
+                                        <div class="grid grid-cols-1 md:[grid-template-columns:1fr_2fr_auto] gap-2 max-w-full">
+                                            <div>
+                                                <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Caption</div>
+                                                <input
+                                                    type="text"
+                                                    wire:model.defer="editing.{{ $id }}.caption"
+                                                    placeholder="Optional caption"
+                                                    class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm
+                                               text-neutral-900 placeholder-neutral-400
+                                               focus:outline-none focus:ring-2 focus:ring-sky-500
+                                               dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+                                                />
+                                                @error('editing.'.$id.'.caption')
+                                                <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
+                                                @enderror
+                                            </div>
+
+                                            <div>
+                                                <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Description</div>
+                                                <input
+                                                    type="text"
+                                                    wire:model.defer="editing.{{ $id }}.description"
+                                                    placeholder="Optional description"
+                                                    class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm
+                                               text-neutral-900 placeholder-neutral-400
+                                               focus:outline-none focus:ring-2 focus:ring-sky-500
+                                               dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+                                                />
+                                                @error('editing.'.$id.'.description')
+                                                <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
+                                                @enderror
+                                            </div>
+
+                                            <div>
+                                                <div class="block text-xs font-medium text-neutral-500 dark:text-neutral-400 mb-1">Order</div>
+                                                <div class="w-20">
+                                                    <input
+                                                        type="number" min="1" step="1"
+                                                        wire:model.defer="editing.{{ $id }}.order"
+                                                        class="block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-sm text-center
+                                                   text-neutral-900 placeholder-neutral-400
+                                                   focus:outline-none focus:ring-2 focus:ring-sky-500
+                                                   dark:bg-neutral-800 dark:border-neutral-700 dark:text-neutral-100 dark:placeholder-neutral-500"
+                                                    />
+                                                </div>
+                                                @error('editing.'.$id.'.order')
+                                                <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
+                                                @enderror
+                                            </div>
+                                        </div>
+                                    @endif
+                                </div>
+
+                                <div class="flex gap-2 self-stretch md:items-center">
+                                    @if (! $isEditing)
+                                        <button
+                                            type="button"
+                                            wire:click="startEdit({{ $id }})"
+                                            class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                            hover:bg-neutral-100 text-neutral-700
+                                            dark:text-neutral-200 dark:hover:bg-neutral-800"
+                                        >
+                                            Edit
+                                        </button>
+                                        <button
+                                            type="button"
+                                            wire:click="confirmDelete({{ $id }})"
+                                            wire:loading.attr="disabled"
+                                            class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                            border border-red-500 text-red-600 hover:bg-red-50
+                                            dark:border-red-600 dark:text-red-400 dark:hover:bg-red-900/20"
+                                        >
+                                            Delete
+                                        </button>
+                                    @else
+                                        <div class="flex items-center gap-2 self-stretch mt-4">
+                                            <button
+                                                type="button"
+                                                wire:click="saveEdit({{ $id }})"
+                                                wire:loading.attr="disabled"
+                                                class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                               border border-sky-500 text-sky-600 hover:bg-sky-50
+                                               dark:border-sky-600 dark:text-sky-400 dark:hover:bg-sky-900/20"
+                                            >
+                                                Save
+                                            </button>
+                                            <button
+                                                type="button"
+                                                wire:click="cancelEdit({{ $id }})"
+                                                class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
+                                               hover:bg-neutral-100 text-neutral-700
+                                               dark:text-neutral-200 dark:hover:bg-neutral-800"
+                                            >
+                                                Cancel
+                                            </button>
+                                        </div>
+                                    @endif
+                                </div>
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
+
+                <!-- Image Preview Overlay (kept as-is) -->
                 <div
                     x-cloak
                     x-show="preview.open"
@@ -446,30 +617,26 @@
                     class="fixed inset-0 z-[60]"
                     aria-modal="true" role="dialog" aria-label="Image preview"
                 >
-                    <!-- Backdrop -->
                     <div class="absolute inset-0 bg-black/80" @click="closePreview()"></div>
-
                     <button
                         type="button"
                         @click="closePreview()"
                         class="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-lg
-                               bg-white/90 text-neutral-700 shadow hover:bg-white
-                               dark:bg-neutral-800/90 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                       bg-white/90 text-neutral-700 shadow hover:bg-white
+                       dark:bg-neutral-800/90 dark:text-neutral-200 dark:hover:bg-neutral-800"
                         aria-label="Close preview"
                     >
                         <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M6 6l12 12M18 6L6 18"/>
                         </svg>
                     </button>
-
-                    <!-- Panel -->
                     <div class="relative mx-auto h-full w-full max-w-5xl">
                         <div class="flex h-full items-center justify-center p-6">
                             <img
                                 :src="preview.url"
                                 :alt="preview.alt"
                                 class="max-h-[85vh] max-w-[90vw] rounded-xl border border-neutral-200 bg-white object-contain shadow-lg
-                                       dark:border-neutral-700 dark:bg-neutral-900"
+                                dark:border-neutral-700 dark:bg-neutral-900"
                                 @click.stop
                                 loading="eager"
                                 decoding="async"
@@ -478,7 +645,6 @@
                     </div>
                 </div>
 
-                {{-- Delete confirmation modal --}}
                 <div
                     x-cloak
                     x-data
@@ -489,7 +655,6 @@
                     aria-modal="true" role="dialog" aria-labelledby="delete-modal-title"
                 >
                     <div class="absolute inset-0 bg-black/80" @click="$wire.cancelDelete()"></div>
-
                     <div class="relative mx-auto mt-24 w-full max-w-md rounded-xl bg-white p-4 shadow-lg dark:bg-neutral-900 border dark:border-neutral-700">
                         @php
                             $toDelete = null;
@@ -497,7 +662,6 @@
                                 $toDelete = collect($items)->firstWhere('id', $confirmingDeleteId);
                             }
                         @endphp
-
                         <div class="flex items-start gap-3">
                             <div>
                                 @if($toDelete && !empty($toDelete['thumb']))
@@ -511,7 +675,6 @@
                                     </div>
                                 @endif
                             </div>
-
                             <div class="flex-1 min-w-0">
                                 <h3 id="delete-modal-title" class="text-base font-semibold text-neutral-900 dark:text-neutral-100">
                                     Delete this file?
@@ -524,14 +687,13 @@
                                 </p>
                             </div>
                         </div>
-
                         <div class="mt-4 flex justify-end gap-2">
                             <button
                                 type="button"
                                 wire:click="cancelDelete"
                                 class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
-                                       bg-neutral-100 text-neutral-800 hover:bg-neutral-200
-                                       dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+                               bg-neutral-100 text-neutral-800 hover:bg-neutral-200
+                               dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
                             >
                                 Cancel
                             </button>
@@ -540,9 +702,9 @@
                                 wire:click="deleteConfirmed()"
                                 wire:loading.attr="disabled"
                                 class="inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium
-                                       bg-red-600 text-white hover:bg-red-500
-                                       focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600/50
-                                       disabled:opacity-60"
+                               bg-red-600 text-white hover:bg-red-500
+                               focus:outline-none focus-visible:ring-2 focus-visible:ring-red-600/50
+                               disabled:opacity-60"
                             >
                                 Delete
                             </button>

--- a/src/Livewire/MediaUploader.php
+++ b/src/Livewire/MediaUploader.php
@@ -41,7 +41,7 @@ class MediaUploader extends Component
     public ?int    $confirmingDeleteId  = null;
     public string  $allowedLabel        = '';
     public ?string $theme               = null;
-    public ?string $pendingModelClass   = null; // new
+    public ?string $pendingModelClass   = null;
     public ?string $channel             = null;
     public bool    $listAll             = false;
     public array   $groups              = [];
@@ -136,7 +136,7 @@ class MediaUploader extends Component
         }
 
         // Editing an existing model: read current max order from DB
-        $model = $this->target();           // now non-null
+        $model = $this->target();
         $collection = $this->collection ?? 'default';
 
         $max = (int) ($model->media()
@@ -292,17 +292,19 @@ class MediaUploader extends Component
         $perFileRules = ['required', $fileRule];
         if (!empty($this->allowedMimes)) $perFileRules[] = 'mimetypes:' . implode(',', $this->allowedMimes);
 
-        $this->validate([
-                            'uploads'   => ['required', 'array'],
-                            'uploads.*' => $perFileRules,
-                        ] + $this->queueMetaRules());
+        $this->validate(
+            [
+                'uploads'   => ['required', 'array'],
+                'uploads.*' => $perFileRules,
+            ] + $this->queueMetaRules()
+        );
 
         if (! $this->hasTarget()) {
             session()->flash('media_uploader_notice', 'Files queued. They will be attached after you save.');
             return;
         }
 
-        $model = $this->target();
+        $model      = $this->target();
         $collection = $this->collection ?? 'default';
         $added      = $replaced = $skipped = $renamed = 0;
 
@@ -373,7 +375,7 @@ class MediaUploader extends Component
         int|string $id,
         ?string $collection = null,
         ?string $disk = null,
-        ?string $channel = null,           // <— NEW
+        ?string $channel = null,
     ): void {
         if ($this->channel && $channel && $channel !== $this->channel) {
             return;


### PR DESCRIPTION
## Summary
Deferred uploads for new models + optional `listAll` grouped view. Tailwind/Bootstrap dark-mode guidance added.

## What’s changed
- Queue uploads before save; attach on `media:attach` → emit `media-attached`.
- `nextOrder()` handles pending queue vs DB for existing targets.
- New prop: `listAll` / `:list-all="true"` → renders all collections, grouped and still editable.
- Tailwind + Bootstrap examples: dark/light notes.

## Backwards compatibility
- No breaking changes; defaults unchanged unless `listAll` or deferred flow is used.

## Screenshots
<img width="300" height="161" alt="screenshot" src="https://github.com/user-attachments/assets/d940b9d8-5e55-4495-abb6-2241e9e01e8c" />


## Checks
- [ ] Queue files → save → auto-attach
- [ ] Name conflict strategies
- [ ] Duplicate detection
- [ ] Grouped view edit/save
- [ ] Docs/CHANGELOG updated (no tag bump yet)