### PR TITLE
refactor(release): prepare v0.4.0 and refactor core architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- 
 
 ### Changed
+- 
 
 ### Fixed
+- 
 
 ---
+
+## [v0.4.0] — 2026-07-15
+
+### Added
+- **`NameConflictStrategy` Enum**: Introduced a strongly-typed Enum for handling name conflicts (`RENAME`, `REPLACE`, `SKIP`, `ALLOW`), replacing raw string checks.
+- **Custom `ModelResolutionException`**: Replaced generic `abort()` calls with a dedicated exception for clearer debugging when model binding fails.
+
+### Changed
+- **Configurable Namespaces**: The component now resolves models using the `model_namespaces` configuration array instead of hardcoded `App\Models` strings, allowing for better support in modular/domain-driven architectures.
+- **Validation Refactor**: Centralized upload validation into a dedicated `rules()` method, simplifying the `uploadFiles()` logic and improving maintainability.
+
+### Fixed
+- Improved exception handling in test suite to correctly capture and assert custom package exceptions.
+- Resolved potential `MassAssignmentException` issues in tests when instantiating standard User models.
+
+## [v0.4.0] — 2026-07-15
+
+### Added
+- **`NameConflictStrategy` Enum**: Introduced a strongly-typed Enum for handling name conflicts (`RENAME`, `REPLACE`, `SKIP`, `ALLOW`), replacing raw string checks.
+- **Custom `ModelResolutionException`**: Replaced generic `abort()` calls with a dedicated exception for clearer debugging when model binding fails.
+
+### Changed
+- **Configurable Namespaces**: The component now resolves models using the `model_namespaces` configuration array instead of hardcoded `App\Models` strings, allowing for better support in modular/domain-driven architectures.
+- **Validation Refactor**: Centralized upload validation into a dedicated `rules()` method, simplifying the `uploadFiles()` logic and improving maintainability.
+
+### Fixed
+- Improved exception handling in test suite to correctly capture and assert custom package exceptions.
+- Resolved potential `MassAssignmentException` issues in tests when instantiating standard User models.
 ## [v0.3.0] — 2025-09-01
 
 ### Added
@@ -107,5 +138,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/codebyray/livewire-media-uploader/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/codebyray/livewire-media-uploader/compare/v0.4.0...HEAD
+[v0.4.0]: https://github.com/codebyray/livewire-media-uploader/releases/tag/v0.4.0
+[v0.3.0]: https://github.com/codebyray/livewire-media-uploader/releases/tag/v0.3.0
+[v0.2.0]: https://github.com/codebyray/livewire-media-uploader/releases/tag/v0.2.0
 [v0.1.0]: https://github.com/codebyray/livewire-media-uploader/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Livewire Media Uploader is a reusable Livewire v3 component that integrates seam
 ## Requirements
 
 - PHP **8.1+**
-- Laravel **10.x | 11.x | 12.x**
-- Livewire **^3.0**
-- spatie/laravel-medialibrary **^10.12**
+- Laravel **^10.0 | ^11.0 | ^12.0 | ^13.0**
+- Livewire **^3.0 | ^4.0**
+- spatie/laravel-medialibrary **^10.12 | ^11.0**
 - TailwindCSS (optional but recommended for the default view)
 - Alpine.js (used by overlays/progress; see [Overlays & UX Notes](#overlays--ux-notes))
 - CSS depending on theme:

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.1",
-        "livewire/livewire": "^3.0",
-        "laravel/framework": "^10.0|^11.0|^12.0|^13.0"
+        "livewire/livewire": "^3.0 || ^4.0",
+        "laravel/framework": "^10.0 || ^11.0 || ^12.0 || ^13.0",
         "spatie/laravel-medialibrary": "^10.12 || ^11.0"
     },
     "require-dev": {

--- a/config/media-uploader.php
+++ b/config/media-uploader.php
@@ -4,6 +4,26 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Model Namespaces
+    |--------------------------------------------------------------------------
+    | Define the namespaces where your Eloquent models are located.
+    |
+    | When passing a class name (e.g., model="Product") to the Livewire component,
+    | the package will iterate through these namespaces to resolve the
+    | Fully Qualified Class Name (FQCN).
+    |
+    | Useful if your models are organized across different directories,
+    | such as "App\Models" or "App\Domain\Models".
+    |
+    | Example:
+    |   'model_namespaces' => ['App\\Models', 'App\\Domain\\Models'],
+    */
+    'model_namespaces' => [
+        'App\\Models',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Active UI Theme
     |--------------------------------------------------------------------------
     | Controls which Blade view is used to render the uploader UI.
@@ -21,7 +41,7 @@ return [
     |
     | Default: 'tailwind'
     */
-    'theme'  => env('MEDIA_UPLOADER_THEME', 'tailwind'),
+    'theme' => env('MEDIA_UPLOADER_THEME', 'tailwind'),
 
     /*
     |--------------------------------------------------------------------------
@@ -50,7 +70,7 @@ return [
     |   />
     */
     'themes' => [
-        'tailwind'  => 'media-uploader::themes.tailwind.media-uploader',
+        'tailwind' => 'media-uploader::themes.tailwind.media-uploader',
         'bootstrap' => 'media-uploader::themes.bootstrap.media-uploader',
         // 'custom' => 'media-uploader::themes.custom.media-uploader',
     ],
@@ -75,8 +95,8 @@ return [
     | preset's validation constraints.
     */
     'collections' => [
-        'avatars'     => 'images',
-        'images'      => 'images',
+        'avatars' => 'images',
+        'images' => 'images',
         'attachments' => 'docs',
     ],
 
@@ -103,9 +123,9 @@ return [
         |  - MEDIA_MAXKB_IMAGES   (integer KB, e.g. 10240 for 10 MB)
         */
         'images' => [
-            'types'   => env('MEDIA_TYPES_IMAGES',  'jpg,jpeg,png,webp,avif,gif'),
-            'mimes'   => env('MEDIA_MIMES_IMAGES',  'image/jpeg,image/png,image/webp,image/avif,image/gif'),
-            'max_kb'  => (int) env('MEDIA_MAXKB_IMAGES', 10240),
+            'types' => env('MEDIA_TYPES_IMAGES', 'jpg,jpeg,png,webp,avif,gif'),
+            'mimes' => env('MEDIA_MIMES_IMAGES', 'image/jpeg,image/png,image/webp,image/avif,image/gif'),
+            'max_kb' => (int) env('MEDIA_MAXKB_IMAGES', 10240),
         ],
 
         // ... existing code ...
@@ -119,9 +139,9 @@ return [
         |  - MEDIA_MAXKB_DOCS     (integer KB, e.g. 20480 for 20 MB)
         */
         'docs' => [
-            'types'   => env('MEDIA_TYPES_DOCS',    'pdf,doc,docx,xls,xlsx,ppt,pptx,txt'),
-            'mimes'   => env('MEDIA_MIMES_DOCS',    'application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain'),
-            'max_kb'  => (int) env('MEDIA_MAXKB_DOCS', 20480),
+            'types' => env('MEDIA_TYPES_DOCS', 'pdf,doc,docx,xls,xlsx,ppt,pptx,txt'),
+            'mimes' => env('MEDIA_MIMES_DOCS', 'application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain'),
+            'max_kb' => (int) env('MEDIA_MAXKB_DOCS', 20480),
         ],
 
         /*
@@ -134,9 +154,9 @@ return [
         |  - MEDIA_MAXKB_VIDEOS   (integer KB, e.g. 102400 for 100 MB)
         */
         'videos' => [
-            'types'   => env('MEDIA_TYPES_VIDEOS',  'mp4,mov,webm'),
-            'mimes'   => env('MEDIA_MIMES_VIDEOS',  'video/mp4,video/quicktime,video/webm'),
-            'max_kb'  => (int) env('MEDIA_MAXKB_VIDEOS', 102400),
+            'types' => env('MEDIA_TYPES_VIDEOS', 'mp4,mov,webm'),
+            'mimes' => env('MEDIA_MIMES_VIDEOS', 'video/mp4,video/quicktime,video/webm'),
+            'max_kb' => (int) env('MEDIA_MAXKB_VIDEOS', 102400),
         ],
 
         /*
@@ -150,9 +170,9 @@ return [
         |  - MEDIA_MAXKB_DEFAULT
         */
         'default' => [
-            'types'   => env('MEDIA_TYPES_DEFAULT', 'jpg,jpeg,png,webp,avif,gif,pdf,doc,docx,xls,xlsx,ppt,pptx,txt'),
-            'mimes'   => env('MEDIA_MIMES_DEFAULT', 'image/jpeg,image/png,image/webp,image/avif,image/gif,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain'),
-            'max_kb'  => (int) env('MEDIA_MAXKB_DEFAULT', 10240),
+            'types' => env('MEDIA_TYPES_DEFAULT', 'jpg,jpeg,png,webp,avif,gif,pdf,doc,docx,xls,xlsx,ppt,pptx,txt'),
+            'mimes' => env('MEDIA_MIMES_DEFAULT', 'image/jpeg,image/png,image/webp,image/avif,image/gif,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain'),
+            'max_kb' => (int) env('MEDIA_MAXKB_DEFAULT', 10240),
         ],
     ],
 ];

--- a/src/Enums/NameConflictStrategy.php
+++ b/src/Enums/NameConflictStrategy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Codebyray\LivewireMediaUploader\Enums;
+
+enum NameConflictStrategy: string
+{
+    case RENAME = 'rename';
+    case REPLACE = 'replace';
+    case SKIP = 'skip';
+    case ALLOW = 'allow';
+}

--- a/src/Exceptions/ModelResolutionException.php
+++ b/src/Exceptions/ModelResolutionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Codebyray\LivewireMediaUploader\Exceptions;
+
+use Exception;
+
+class ModelResolutionException extends Exception {}

--- a/src/Livewire/MediaUploader.php
+++ b/src/Livewire/MediaUploader.php
@@ -2,10 +2,13 @@
 
 namespace Codebyray\LivewireMediaUploader\Livewire;
 
+use Codebyray\LivewireMediaUploader\Enums\NameConflictStrategy;
+use Codebyray\LivewireMediaUploader\Exceptions\ModelResolutionException;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\File as FileRule;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -13,13 +16,12 @@ use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\WithFileUploads;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
-use Illuminate\Validation\Rules\File as FileRule;
 
 class MediaUploader extends Component
 {
     use WithFileUploads;
 
-    public array   $namespaces          = ['App\\Models'];
+    public array   $namespaces          = [];
     public array   $aliases             = [];
     public ?string $collection          = 'images';
     public ?string $disk                = null;
@@ -35,7 +37,7 @@ class MediaUploader extends Component
     public ?string $preset              = null;
     public array   $allowedTypes        = [];
     public array   $allowedMimes        = [];
-    public string  $attachedFilesTitle  = "Current gallery";
+    public string  $attachedFilesTitle  = 'Current gallery';
     public array   $editing             = [];
     public array   $pendingMeta         = [];
     public ?int    $confirmingDeleteId  = null;
@@ -47,9 +49,10 @@ class MediaUploader extends Component
     public array   $groups              = [];
 
     #[Locked]
-    public ?string         $resolvedModelClass = null;
+    public ?string $resolvedModelClass = null;
+
     #[Locked]
-    public int|string|null $resolvedModelId    = null;
+    public int|string|null $resolvedModelId = null;
 
     public function mount(
         $for = null,
@@ -61,47 +64,51 @@ class MediaUploader extends Component
         ?string $accept = null,
         bool $showList = true,
         int $maxSizeKb = 10240,
-        array $namespaces = null,
-        array $aliases = null,
-        string $attachedFilesTitle = "Attached media",
+        ?array $namespaces = null,
+        ?array $aliases = null,
+        string $attachedFilesTitle = 'Attached media',
         ?string $channel = null,
         bool $listAll = false,
     ): void {
-        if ($namespaces !== null) $this->namespaces = $namespaces;
-        if ($aliases !== null)    $this->aliases    = $aliases;
+        // Load namespaces from config
+        $this->namespaces = $namespaces ?? config('media-uploader.model_namespaces', ['App\\Models']);
+        $this->aliases = $aliases ?? [];
 
-        $this->channel            = $channel;
-        $this->collection         = $collection ?: 'images';
-        $this->disk               = $disk;
-        $this->multiple           = $multiple;
-        $this->accept             = $accept;
-        $this->showList           = $showList;
-        $this->maxSizeKb          = $maxSizeKb;
+        $this->channel = $channel;
+        $this->collection = $collection ?: 'images';
+        $this->disk = $disk;
+        $this->multiple = $multiple;
+        $this->accept = $accept;
+        $this->showList = $showList;
+        $this->maxSizeKb = $maxSizeKb;
         $this->attachedFilesTitle = $attachedFilesTitle;
-        $this->listAll            = $listAll;
+        $this->listAll = $listAll;
 
         $this->loadPresetFromConfig();
 
         if ($for instanceof Model) {
-            if (! $for->exists) abort(422, 'Target model must be saved before attaching media.');
-            if (! $for instanceof HasMedia) abort(422, class_basename($for) . ' must implement Spatie\\MediaLibrary\\HasMedia.');
+            if (! $for->exists) {
+                throw new ModelResolutionException('Target model must be saved before attaching media.');
+            }
+            if (! $for instanceof HasMedia) {
+                throw new ModelResolutionException(class_basename($for).' must implement Spatie\\MediaLibrary\\HasMedia.');
+            }
             $this->resolvedModelClass = $for::class;
-            $this->resolvedModelId    = (string) $for->getKey();
+            $this->resolvedModelId = (string) $for->getKey();
         } elseif ($model) {
             $fqcn = $this->resolveModelClass($model);
             if (! in_array(HasMedia::class, class_implements($fqcn), true)) {
-                abort(422, class_basename($fqcn) . ' must implement Spatie\\MediaLibrary\\HasMedia.');
+                throw new ModelResolutionException(class_basename($fqcn).' must implement Spatie\\MediaLibrary\\HasMedia.');
             }
             if ($id !== null) {
                 $fqcn::findOrFail($id);
                 $this->resolvedModelClass = $fqcn;
-                $this->resolvedModelId    = (string) $id;
+                $this->resolvedModelId = (string) $id;
             } else {
-                // PENDING: we only know the class for now
                 $this->pendingModelClass = $fqcn;
             }
         } else {
-            abort(422, 'Provide either :for="$model" or model="Class" (id optional).');
+            throw new ModelResolutionException('Provide either :for="$model" or model="Class" (id optional).');
         }
 
         if ($this->showList && $this->hasTarget()) {
@@ -109,67 +116,78 @@ class MediaUploader extends Component
         }
     }
 
-    protected function metaRules(int $mediaId): array
+    /**
+     * Refactored: Centralized validation rules
+     */
+    protected function rules(): array
     {
+        $fileRule = FileRule::defaults();
+        if (($this->preset ?? null) === 'images') {
+            $fileRule = $fileRule->image();
+        }
+        if (! empty($this->allowedTypes)) {
+            $fileRule = $fileRule->types($this->allowedTypes);
+        }
+        if (! empty($this->maxSizeKb)) {
+            $fileRule = $fileRule->max($this->maxSizeKb);
+        }
+
+        $perFileRules = ['required', $fileRule];
+        if (! empty($this->allowedMimes)) {
+            $perFileRules[] = 'mimetypes:'.implode(',', $this->allowedMimes);
+        }
+
         return [
-            "editing.$mediaId.caption"     => ['nullable', 'string', 'max:255'],
-            "editing.$mediaId.description" => ['nullable', 'string', 'max:2000'],
-            "editing.$mediaId.order"       => ['nullable', 'integer', 'min:1'],
-        ];
+            'uploads' => ['required', 'array'],
+            'uploads.*' => $perFileRules,
+        ] + $this->queueMetaRules();
     }
 
     protected function queueMetaRules(): array
     {
         return [
-            'pendingMeta.*.caption'     => ['nullable', 'string', 'max:255'],
+            'pendingMeta.*.caption' => ['nullable', 'string', 'max:255'],
             'pendingMeta.*.description' => ['nullable', 'string', 'max:2000'],
-            'pendingMeta.*.order'       => ['nullable', 'integer', 'min:1'],
+            'pendingMeta.*.order' => ['nullable', 'integer', 'min:1'],
         ];
     }
 
     protected function nextOrder(): int
     {
-        // While creating: base order from queued items only
         if (! $this->hasTarget()) {
             $maxPending = (int) collect($this->pendingMeta ?? [])->pluck('order')->max();
+
             return ($maxPending ?: 0) + 1;
         }
 
-        // Editing an existing model: read current max order from DB
         $model = $this->target();
         $collection = $this->collection ?? 'default';
-
-        $max = (int) ($model->media()
-            ->where('collection_name', $collection)
-            ->max('order_column') ?? 0);
+        $max = (int) ($model->media()->where('collection_name', $collection)->max('order_column') ?? 0);
 
         return $max + 1;
     }
 
-
     protected function csvToArray(?string $csv): array
     {
-        return collect(explode(',', (string) $csv))
-            ->map(fn ($s) => trim($s))
-            ->filter()
-            ->values()
-            ->all();
+        return collect(explode(',', (string) $csv))->map(fn ($s) => trim($s))->filter()->values()->all();
     }
 
     protected function buildAccept(array $mimes, array $exts): ?string
     {
         $a = [];
-        foreach ($mimes as $m) $a[] = $m;
-        foreach ($exts as $e)  $a[] = '.' . ltrim($e, '.');
+        foreach ($mimes as $m) {
+            $a[] = $m;
+        }
+        foreach ($exts as $e) {
+            $a[] = '.'.ltrim($e, '.');
+        }
+
         return $a ? implode(',', array_unique($a)) : null;
     }
 
     protected function loadPresetFromConfig(): void
     {
-        $presetKey = $this->preset
-            ?? config('media-uploader.collections.' . ($this->collection ?? 'default'))
-            ?? 'default';
-
+        $presetKey = $this->preset ?? config('media-uploader.collections.'.($this->collection ?? 'default')) ?? 'default';
         $cfg = (array) config("media-uploader.presets.$presetKey", []);
         $this->allowedTypes = $this->csvToArray($cfg['types'] ?? '');
         $this->allowedMimes = $this->csvToArray($cfg['mimes'] ?? '');
@@ -180,98 +198,93 @@ class MediaUploader extends Component
 
         if (empty($this->accept) && config('media-uploader.accept_from_config')) {
             $accept = $this->buildAccept($this->allowedMimes, $this->allowedTypes);
-            if ($accept) $this->accept = $accept;
+            if ($accept) {
+                $this->accept = $accept;
+            }
         }
-
         $this->refreshAllowedLabel();
     }
 
     protected function resolveModelClass(string $value): string
     {
         $value = trim($value);
-
         if (isset($this->aliases[$value]) && class_exists($this->aliases[$value])) {
             return $this->aliases[$value];
         }
-
-        if (class_exists($value)) return $value;
-
+        if (class_exists($value)) {
+            return $value;
+        }
         if ($morphed = Relation::getMorphedModel($value)) {
             return $morphed;
         }
 
-        $raw   = trim($value, " \t\n\r\0\x0B\\/.");
+        $raw = trim($value, " \t\n\r\0\x0B\\/.");
         $parts = preg_split('/[.\/\\\\]+/', $raw) ?: [];
         $parts = array_map(fn ($p) => Str::studly($p), array_filter($parts));
 
-        if (empty($parts)) abort(422, "Unknown model class/alias [{$value}].");
+        if (empty($parts)) {
+            throw new ModelResolutionException("Unknown model class/alias [{$value}].");
+        }
 
         $candidates = [];
         foreach ($this->namespaces as $ns) {
-            $candidates[] = rtrim($ns, '\\') . '\\' . implode('\\', $parts);
+            $candidates[] = rtrim($ns, '\\').'\\'.implode('\\', $parts);
             if (count($parts) >= 1) {
                 $alt = $parts;
-                $alt[count($alt)-1] = Str::studly(Str::singular($alt[count($alt)-1]));
-                $candidates[] = rtrim($ns, '\\') . '\\' . implode('\\', $alt);
+                $alt[count($alt) - 1] = Str::studly(Str::singular($alt[count($alt) - 1]));
+                $candidates[] = rtrim($ns, '\\').'\\'.implode('\\', $alt);
             }
             if (count($parts) === 1) {
-                $candidates[] = rtrim($ns, '\\') . '\\' . $parts[0];
-                $candidates[] = rtrim($ns, '\\') . '\\' . Str::studly(Str::singular($parts[0]));
+                $candidates[] = rtrim($ns, '\\').'\\'.$parts[0];
+                $candidates[] = rtrim($ns, '\\').'\\'.Str::studly(Str::singular($parts[0]));
             }
         }
 
         foreach (array_unique($candidates) as $fqcn) {
-            if (class_exists($fqcn)) return $fqcn;
+            if (class_exists($fqcn)) {
+                return $fqcn;
+            }
         }
 
-        abort(422, "Unknown model class/alias [{$value}].");
+        throw new ModelResolutionException("Unknown model class/alias [{$value}].");
     }
 
     protected function hasTarget(): bool
     {
-        // these are typed but may be uninitialized; isset() is safe
         return isset($this->resolvedModelClass, $this->resolvedModelId)
             && $this->resolvedModelClass !== ''
             && $this->resolvedModelId !== null
             && $this->resolvedModelId !== '';
     }
 
-
-    // change return type to ?Model
     protected function target(): ?Model
     {
-        if (! $this->hasTarget()) return null;
-
+        if (! $this->hasTarget()) {
+            return null;
+        }
         $cls = $this->resolvedModelClass;
+
         return $cls::findOrFail($this->resolvedModelId);
     }
-
 
     public function updatedUploads(): void
     {
         $list = is_array($this->uploads) ? $this->uploads : [];
         $baseOrder = $this->nextOrder();
 
-        $this->selected = collect($list)->filter()->map(function ($f, $i) use ($baseOrder)  {
-            $name = method_exists($f, 'getClientOriginalName')
-                ? $f->getClientOriginalName()
-                : (property_exists($f, 'name') ? $f->name : 'file');
-
-            $size = method_exists($f, 'getSize')
-                ? $f->getSize()
-                : (property_exists($f, 'size') ? $f->size : 0);
+        $this->selected = collect($list)->filter()->map(function ($f, $i) use ($baseOrder) {
+            $name = method_exists($f, 'getClientOriginalName') ? $f->getClientOriginalName() : (property_exists($f, 'name') ? $f->name : 'file');
+            $size = method_exists($f, 'getSize') ? $f->getSize() : (property_exists($f, 'size') ? $f->size : 0);
 
             $this->pendingMeta[$i] = $this->pendingMeta[$i] ?? [
-                'caption'     => null,
-                'description' => null,
-                'order'       => $baseOrder + $i,
+                'caption' => null, 'description' => null, 'order' => $baseOrder + $i,
             ];
 
             return [
                 'queue_key' => $i,
-                'name'      => (string) $name,
-                'size'      => (int) $size,
-                'is_image'  => $this->isImageLike($f),
+                'name' => (string) $name,
+                'size' => (int) $size,
+                'is_image' => $this->isImageLike($f),
             ];
         })->values()->all();
     }
@@ -284,148 +297,146 @@ class MediaUploader extends Component
 
     public function uploadFiles(): void
     {
-        $fileRule = FileRule::defaults();
-        if (($this->preset ?? null) === 'images') $fileRule = $fileRule->image();
-        if (!empty($this->allowedTypes)) $fileRule = $fileRule->types($this->allowedTypes);
-        if (!empty($this->maxSizeKb))    $fileRule = $fileRule->max($this->maxSizeKb);
-
-        $perFileRules = ['required', $fileRule];
-        if (!empty($this->allowedMimes)) $perFileRules[] = 'mimetypes:' . implode(',', $this->allowedMimes);
-
-        $this->validate(
-            [
-                'uploads'   => ['required', 'array'],
-                'uploads.*' => $perFileRules,
-            ] + $this->queueMetaRules()
-        );
+        $this->validate($this->rules());
 
         if (! $this->hasTarget()) {
             session()->flash('media_uploader_notice', 'Files queued. They will be attached after you save.');
+
             return;
         }
 
-        $model      = $this->target();
+        $model = $this->target();
         $collection = $this->collection ?? 'default';
-        $added      = $replaced = $skipped = $renamed = 0;
+        $added = $replaced = $skipped = $renamed = 0;
+
+        // Enum strategy integration
+        $strategy = NameConflictStrategy::tryFrom($this->onNameConflict) ?? NameConflictStrategy::RENAME;
 
         foreach ($this->uploads as $i => $file) {
-            $originalName = method_exists($file, 'getClientOriginalName')
-                ? $file->getClientOriginalName()
-                : (property_exists($file, 'name') ? $file->name : 'file');
+            $originalName = method_exists($file, 'getClientOriginalName') ? $file->getClientOriginalName() : (property_exists($file, 'name') ? $file->name : 'file');
 
             $hash = $this->skipExactDuplicates ? $this->fileSha256($file) : null;
             if ($this->skipExactDuplicates && $hash) {
-                $existsSameHash = $model->media()
-                    ->where('collection_name', $collection)
-                    ->where('custom_properties->sha256', $hash)
-                    ->first();
+                $existsSameHash = $model->media()->where('collection_name', $collection)->where('custom_properties->sha256', $hash)->first();
+                if ($existsSameHash) {
+                    $skipped++;
 
-                if ($existsSameHash) { $skipped++; continue; }
+                    continue;
+                }
             }
 
             $targetName = $originalName;
-            if ($this->onNameConflict !== 'allow') {
+            if ($strategy !== NameConflictStrategy::ALLOW) {
                 if ($conflict = $this->existingByName($model, $collection, $targetName)) {
-                    switch ($this->onNameConflict) {
-                        case 'replace': $conflict->delete(); $replaced++; break;
-                        case 'skip':    $skipped++; continue 2;
-                        case 'rename':  $targetName = $this->uniqueFileName($model, $collection, $originalName); $renamed++; break;
+                    switch ($strategy) {
+                        case NameConflictStrategy::REPLACE:
+                            $conflict->delete();
+                            $replaced++;
+                            break;
+                        case NameConflictStrategy::SKIP:
+                            $skipped++;
+
+                            continue 2;
+                        case NameConflictStrategy::RENAME:
+                            $targetName = $this->uniqueFileName($model, $collection, $originalName);
+                            $renamed++;
+                            break;
                     }
                 }
             }
 
             $adder = $model->addMedia($file)->usingFileName($targetName);
-            if ($hash) $adder->withCustomProperties(['sha256' => $hash]);
+            if ($hash) {
+                $adder->withCustomProperties(['sha256' => $hash]);
+            }
 
-            $media = $this->disk
-                ? $adder->toMediaCollection($collection, $this->disk)
-                : $adder->toMediaCollection($collection);
-
+            $media = $this->disk ? $adder->toMediaCollection($collection, $this->disk) : $adder->toMediaCollection($collection);
             $meta = $this->pendingMeta[$i] ?? ['caption' => null, 'description' => null, 'order' => null];
 
             $media->setCustomProperty('caption', $meta['caption'] ?: null);
             $media->setCustomProperty('description', $meta['description'] ?: null);
-
-            if (!empty($meta['order'])) {
+            if (! empty($meta['order'])) {
                 $media->order_column = (int) $meta['order'];
             }
             $media->save();
-
             $added++;
         }
 
         $this->clearQueue();
         $this->pendingMeta = [];
-        if ($this->showList) $this->loadItems();
+        if ($this->showList) {
+            $this->loadItems();
+        }
 
         $parts = [];
-        if ($added)    $parts[] = "{$added} added";
-        if ($renamed)  $parts[] = "{$renamed} renamed";
-        if ($replaced) $parts[] = "{$replaced} replaced";
-        if ($skipped)  $parts[] = "{$skipped} skipped";
-        $msg = $parts ? ('Upload complete: ' . implode(', ', $parts) . '.') : 'Nothing uploaded.';
+        if ($added) {
+            $parts[] = "{$added} added";
+        }
+        if ($renamed) {
+            $parts[] = "{$renamed} renamed";
+        }
+        if ($replaced) {
+            $parts[] = "{$replaced} replaced";
+        }
+        if ($skipped) {
+            $parts[] = "{$skipped} skipped";
+        }
 
+        $msg = $parts ? ('Upload complete: '.implode(', ', $parts).'.') : 'Nothing uploaded.';
         $this->dispatch('media-uploaded');
         session()->flash('media_uploader_notice', $msg);
     }
 
     #[On('media:attach')]
-    public function attachTo(
-        string $model,
-        int|string $id,
-        ?string $collection = null,
-        ?string $disk = null,
-        ?string $channel = null,
-    ): void {
+    public function attachTo(string $model, int|string $id, ?string $collection = null, ?string $disk = null, ?string $channel = null): void
+    {
         if ($this->channel && $channel && $channel !== $this->channel) {
             return;
         }
 
         $fqcn = $this->resolveModelClass($model);
         if (! in_array(HasMedia::class, class_implements($fqcn), true)) {
-            abort(422, class_basename($fqcn) . ' must implement Spatie\\MediaLibrary\\HasMedia.');
+            throw new ModelResolutionException(class_basename($fqcn).' must implement Spatie\\MediaLibrary\\HasMedia.');
         }
         $fqcn::findOrFail($id);
 
         $this->resolvedModelClass = $fqcn;
-        $this->resolvedModelId    = (string) $id;
+        $this->resolvedModelId = (string) $id;
 
         $origCollection = $this->collection;
-        $origDisk       = $this->disk;
-        if ($collection) $this->collection = $collection;
-        if ($disk)       $this->disk       = $disk;
+        $origDisk = $this->disk;
+        if ($collection) {
+            $this->collection = $collection;
+        }
+        if ($disk) {
+            $this->disk = $disk;
+        }
 
-        if (!empty($this->uploads)) {
+        if (! empty($this->uploads)) {
             $this->uploadFiles();
         }
 
         $this->collection = $origCollection;
-        $this->disk       = $origDisk;
-
+        $this->disk = $origDisk;
         $this->dispatch('media-attached', model: $fqcn, id: (string) $id, channel: $channel);
     }
-
 
     public function remove(int $mediaId): void
     {
         $media = Media::findOrFail($mediaId);
-
-        $belongs = $media->model_type === $this->resolvedModelClass
-            && (string) $media->model_id === (string) $this->resolvedModelId;
-
+        $belongs = $media->model_type === $this->resolvedModelClass && (string) $media->model_id === (string) $this->resolvedModelId;
         abort_unless($belongs, 403, 'This media does not belong to the specified model.');
-
         $media->delete();
-
-        if ($this->showList) $this->loadItems();
-
+        if ($this->showList) {
+            $this->loadItems();
+        }
         $this->dispatch('media-deleted', id: $mediaId);
     }
 
     public function removeFromQueue(int $queueKey): void
     {
         unset($this->uploads[$queueKey], $this->pendingMeta[$queueKey]);
-        $this->uploads     = array_values($this->uploads);
+        $this->uploads = array_values($this->uploads);
         $this->pendingMeta = array_values($this->pendingMeta);
         $this->updatedUploads();
     }
@@ -434,26 +445,28 @@ class MediaUploader extends Component
     {
         if ($file instanceof TemporaryUploadedFile) {
             $mime = $file->getClientMimeType() ?: $file->getMimeType();
-            if (is_string($mime) && str_starts_with($mime, 'image/')) return true;
+            if (is_string($mime) && str_starts_with($mime, 'image/')) {
+                return true;
+            }
+            $ext = strtolower($file->getClientOriginalExtension() ?: pathinfo($file->getClientOriginalName(), PATHINFO_EXTENSION));
 
-            $ext = strtolower($file->getClientOriginalExtension()
-                                  ?: pathinfo($file->getClientOriginalName(), PATHINFO_EXTENSION));
-            return in_array($ext, ['jpg','jpeg','png','gif','webp','bmp','svg','tif','tiff','avif'], true);
+            return in_array($ext, ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg', 'tif', 'tiff', 'avif'], true);
         }
+
         return false;
     }
 
     public function loadItems(): void
     {
         if (! $this->hasTarget()) {
-            $this->items  = [];
+            $this->items = [];
             $this->groups = [];
+
             return;
         }
 
-        $model      = $this->target();
+        $model = $this->target();
         $collection = $this->collection ?? 'default';
-
         $query = $model->media()->orderBy('order_column')->orderBy('id');
 
         if (! $this->listAll) {
@@ -463,68 +476,54 @@ class MediaUploader extends Component
         }
 
         $media = $query->get();
-
         $flat = $media->map(function (Media $m) {
             $thumb = $m->hasGeneratedConversion('thumb') ? $m->getUrl('thumb') : $m->getUrl();
+
             return [
-                'id'          => $m->id,
-                'file_name'   => $m->file_name,
-                'name'        => $m->name,
-                'url'         => $m->getUrl(),
-                'thumb'       => $thumb,
-                'size'        => $m->size,
-                'mime'        => $m->mime_type,
-                'created'     => $m->created_at?->toDateTimeString(),
-                'caption'     => $m->getCustomProperty('caption'),
-                'description' => $m->getCustomProperty('description'),
-                'order'       => (int) $m->order_column,
-                'collection'  => $m->collection_name, // <— important for grouping
-                'is_image'    => str_starts_with((string) $m->mime_type, 'image/'),
+                'id' => $m->id, 'file_name' => $m->file_name, 'name' => $m->name, 'url' => $m->getUrl(),
+                'thumb' => $thumb, 'size' => $m->size, 'mime' => $m->mime_type, 'created' => $m->created_at?->toDateTimeString(),
+                'caption' => $m->getCustomProperty('caption'), 'description' => $m->getCustomProperty('description'),
+                'order' => (int) $m->order_column, 'collection' => $m->collection_name,
+                'is_image' => str_starts_with((string) $m->mime_type, 'image/'),
             ];
         })->values()->all();
 
         $this->items = $flat;
-
-        $this->groups = collect($flat)
-            ->groupBy('collection')
-            ->map(fn ($c) => $c->values()->all())
-            ->toArray();
+        $this->groups = collect($flat)->groupBy('collection')->map(fn ($c) => $c->values()->all())->toArray();
     }
-
 
     public function startEdit(int $mediaId): void
     {
         $item = collect($this->items)->firstWhere('id', $mediaId);
-        if (! $item) return;
-
+        if (! $item) {
+            return;
+        }
         $this->editing[$mediaId] = [
-            'caption'     => $item['caption'] ?? null,
+            'caption' => $item['caption'] ?? null,
             'description' => $item['description'] ?? null,
-            'order'       => $item['order'] ?? null,
+            'order' => $item['order'] ?? null,
         ];
     }
 
     public function saveEdit(int $mediaId): void
     {
         $this->validate($this->metaRules($mediaId));
-
         $media = Media::findOrFail($mediaId);
-        $belongs = $media->model_type === $this->resolvedModelClass
-            && (string) $media->model_id === (string) $this->resolvedModelId;
+        $belongs = $media->model_type === $this->resolvedModelClass && (string) $media->model_id === (string) $this->resolvedModelId;
         abort_unless($belongs, 403, 'This media does not belong to the specified model.');
 
         $meta = $this->editing[$mediaId] ?? ['caption' => null, 'description' => null, 'order' => null];
-
         $media->setCustomProperty('caption', $meta['caption'] ?: null);
         $media->setCustomProperty('description', $meta['description'] ?: null);
-
-        if (!empty($meta['order'])) {
+        if (! empty($meta['order'])) {
             $media->order_column = (int) $meta['order'];
         }
         $media->save();
 
         unset($this->editing[$mediaId]);
-        if ($this->showList) $this->loadItems();
+        if ($this->showList) {
+            $this->loadItems();
+        }
 
         $this->dispatch('media-meta-updated', id: $mediaId);
         session()->flash('media_uploader_notice', 'Media details updated.');
@@ -535,37 +534,39 @@ class MediaUploader extends Component
         unset($this->editing[$mediaId]);
     }
 
+    protected function metaRules(int $mediaId): array
+    {
+        return [
+            "editing.$mediaId.caption" => ['nullable', 'string', 'max:255'],
+            "editing.$mediaId.description" => ['nullable', 'string', 'max:2000'],
+            "editing.$mediaId.order" => ['nullable', 'integer', 'min:1'],
+        ];
+    }
+
     protected function fileSha256(mixed $file): ?string
     {
         $path = method_exists($file, 'getRealPath') ? $file->getRealPath() : null;
-        if (! $path || ! is_file($path)) return null;
+        if (! $path || ! is_file($path)) {
+            return null;
+        }
 
         return hash_file('sha256', $path);
     }
 
     protected function existingByName(Model $model, string $collection, string $fileName): ?Media
     {
-        return $model->media()
-            ->where('collection_name', $collection)
-            ->where('file_name', $fileName)
-            ->first();
+        return $model->media()->where('collection_name', $collection)->where('file_name', $fileName)->first();
     }
 
     protected function uniqueFileName(Model $model, string $collection, string $original): string
     {
-        $base      = pathinfo($original, PATHINFO_FILENAME);
-        $ext       = pathinfo($original, PATHINFO_EXTENSION);
-        $suffix    = 0;
+        $base = pathinfo($original, PATHINFO_FILENAME);
+        $ext = pathinfo($original, PATHINFO_EXTENSION);
+        $suffix = 0;
         $candidate = $original;
-
-        while (
-        $model->media()
-            ->where('collection_name', $collection)
-            ->where('file_name', $candidate)
-            ->exists()
-        ) {
+        while ($model->media()->where('collection_name', $collection)->where('file_name', $candidate)->exists()) {
             $suffix++;
-            $candidate = $base . ' (' . $suffix . ')' . ($ext ? ".{$ext}" : '');
+            $candidate = $base.' ('.$suffix.')'.($ext ? ".{$ext}" : '');
         }
 
         return $candidate;
@@ -585,24 +586,28 @@ class MediaUploader extends Component
     {
         $id = $this->confirmingDeleteId;
         $this->confirmingDeleteId = null;
-
-        if ($id) $this->remove($id);
+        if ($id) {
+            $this->remove($id);
+        }
     }
 
     protected function refreshAllowedLabel(): void
     {
-        $types = is_array($this->allowedTypes)
-            ? $this->allowedTypes
-            : explode(',', (string) $this->allowedTypes);
-
+        $types = is_array($this->allowedTypes) ? $this->allowedTypes : explode(',', (string) $this->allowedTypes);
         $exts = array_values(array_unique(array_filter(array_map(function ($t) {
             $t = strtolower(trim($t));
-            if ($t === '') return null;
-            if (str_starts_with($t, '.')) $t = substr($t, 1);
-            if (!preg_match('/^[a-z0-9]+$/', $t)) return null;
+            if ($t === '') {
+                return null;
+            }
+            if (str_starts_with($t, '.')) {
+                $t = substr($t, 1);
+            }
+            if (! preg_match('/^[a-z0-9]+$/', $t)) {
+                return null;
+            }
+
             return strtolower($t);
         }, $types))));
-
         $this->allowedLabel = $exts ? implode(', ', $exts) : '';
     }
 

--- a/tests/Feature/MediaUploaderTest.php
+++ b/tests/Feature/MediaUploaderTest.php
@@ -1,8 +1,12 @@
 <?php
 
+use Codebyray\LivewireMediaUploader\Enums\NameConflictStrategy;
+use Codebyray\LivewireMediaUploader\Exceptions\ModelResolutionException;
 use Codebyray\LivewireMediaUploader\Livewire\MediaUploader;
-use Codebyray\LivewireMediaUploader\Tests\Fixtures\TestPost;
 use Codebyray\LivewireMediaUploader\Tests\Fixtures\TestableMediaUploader;
+use Codebyray\LivewireMediaUploader\Tests\Fixtures\TestPost;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\View\ViewException;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Livewire\Livewire;
 
@@ -10,7 +14,7 @@ it('renders the component', function () {
     $post = TestPost::create(['title' => 'Hello']);
 
     Livewire::test(MediaUploader::class, [
-        'for'        => $post,
+        'for' => $post,
         'collection' => 'images',
     ])->assertSee('Manage gallery');
 });
@@ -20,9 +24,9 @@ it('uploads a single image and lists it', function () {
     $file = TemporaryUploadedFile::fake()->image('one.jpg', 100, 100)->size(200); // KB
 
     Livewire::test(MediaUploader::class, [
-        'for'        => $post,
+        'for' => $post,
         'collection' => 'images',
-        'preset'     => 'images',
+        'preset' => 'images',
     ])
         ->set('uploads', [$file])
         ->set('pendingMeta.0.caption', 'Cover')
@@ -47,9 +51,9 @@ it('renames on name conflict by default', function () {
 
     // First upload
     Livewire::test(MediaUploader::class, [
-        'for'            => $post,
-        'collection'     => 'images',
-        'preset'         => 'images',
+        'for' => $post,
+        'collection' => 'images',
+        'preset' => 'images',
         'onNameConflict' => 'rename',
     ])
         ->set('uploads', [$f1])
@@ -57,9 +61,9 @@ it('renames on name conflict by default', function () {
 
     // Second upload with same name
     Livewire::test(MediaUploader::class, [
-        'for'            => $post,
-        'collection'     => 'images',
-        'preset'         => 'images',
+        'for' => $post,
+        'collection' => 'images',
+        'preset' => 'images',
         'onNameConflict' => 'rename',
     ])
         ->set('uploads', [$f2])
@@ -79,18 +83,18 @@ it('replaces on name conflict when configured', function () {
     $f2 = TemporaryUploadedFile::fake()->image('doc.png', 50, 50)->size(60);
 
     Livewire::test(MediaUploader::class, [
-        'for'            => $post,
-        'collection'     => 'images',
-        'preset'         => 'images',
+        'for' => $post,
+        'collection' => 'images',
+        'preset' => 'images',
         'onNameConflict' => 'replace',
     ])
         ->set('uploads', [$f1])
         ->call('uploadFiles');
 
     Livewire::test(MediaUploader::class, [
-        'for'            => $post,
-        'collection'     => 'images',
-        'preset'         => 'images',
+        'for' => $post,
+        'collection' => 'images',
+        'preset' => 'images',
         'onNameConflict' => 'replace',
     ])
         ->set('uploads', [$f2])
@@ -108,18 +112,18 @@ it('skips exact duplicates when enabled', function () {
     $t2 = TemporaryUploadedFile::fake()->image('fixed.jpg', 80, 80)->size(150);
 
     Livewire::test(TestableMediaUploader::class, [
-        'for'                 => $post,
-        'collection'          => 'images',
-        'preset'              => 'images',
+        'for' => $post,
+        'collection' => 'images',
+        'preset' => 'images',
         'skipExactDuplicates' => true,
     ])
         ->set('uploads', [$t1])
         ->call('uploadFiles');
 
     Livewire::test(TestableMediaUploader::class, [
-        'for'                 => $post,
-        'collection'          => 'images',
-        'preset'              => 'images',
+        'for' => $post,
+        'collection' => 'images',
+        'preset' => 'images',
         'skipExactDuplicates' => true,
     ])
         ->set('uploads', [$t2])
@@ -134,10 +138,10 @@ it('updates metadata via inline edit', function () {
 
     // Upload one
     Livewire::test(MediaUploader::class, [
-        'for'        => $post,
+        'for' => $post,
         'collection' => 'images',
-        'preset'     => 'images',
-        'showList'   => true,
+        'preset' => 'images',
+        'showList' => true,
     ])
         ->set('uploads', [$file])
         ->call('uploadFiles');
@@ -146,9 +150,9 @@ it('updates metadata via inline edit', function () {
 
     // Edit its meta
     Livewire::test(MediaUploader::class, [
-        'for'        => $post,
+        'for' => $post,
         'collection' => 'images',
-        'showList'   => true,
+        'showList' => true,
     ])
         ->call('startEdit', $m->id)
         ->set("editing.{$m->id}.caption", 'New cap')
@@ -168,10 +172,10 @@ it('deletes media via confirmation flow', function () {
     $file = TemporaryUploadedFile::fake()->image('gone.jpg', 40, 40);
 
     Livewire::test(MediaUploader::class, [
-        'for'        => $post,
+        'for' => $post,
         'collection' => 'images',
-        'preset'     => 'images',
-        'showList'   => true,
+        'preset' => 'images',
+        'showList' => true,
     ])
         ->set('uploads', [$file])
         ->call('uploadFiles');
@@ -179,9 +183,9 @@ it('deletes media via confirmation flow', function () {
     $m = $post->getFirstMedia('images');
 
     Livewire::test(MediaUploader::class, [
-        'for'        => $post,
+        'for' => $post,
         'collection' => 'images',
-        'showList'   => true,
+        'showList' => true,
     ])
         ->call('confirmDelete', $m->id)
         ->call('deleteConfirmed')
@@ -189,4 +193,60 @@ it('deletes media via confirmation flow', function () {
 
     $post->refresh();
     expect($post->getMedia('images'))->toHaveCount(0);
+});
+
+it('skips on name conflict when configured', function () {
+    $post = TestPost::create(['title' => 'Hello']);
+
+    $f1 = TemporaryUploadedFile::fake()->image('doc.png', 50, 50)->size(50);
+    $f2 = TemporaryUploadedFile::fake()->image('doc.png', 50, 50)->size(60);
+
+    // Upload first file
+    Livewire::test(MediaUploader::class, [
+        'for' => $post,
+        'onNameConflict' => NameConflictStrategy::SKIP->value,
+    ])
+        ->set('uploads', [$f1])
+        ->call('uploadFiles');
+
+    // Attempt to upload second file with same name
+    Livewire::test(MediaUploader::class, [
+        'for' => $post,
+        'onNameConflict' => NameConflictStrategy::SKIP->value,
+    ])
+        ->set('uploads', [$f2])
+        ->call('uploadFiles');
+
+    // Assert count remains 1 and the existing file is the original one
+    expect($post->getMedia('images'))->toHaveCount(1)
+        ->and($post->getFirstMedia('images')->file_name)->toBe('doc.png');
+});
+
+it('throws ModelResolutionException if model is not saved', function () {
+    $post = new TestPost(['title' => 'Unsaved Post']);
+
+    try {
+        Livewire::test(MediaUploader::class, ['for' => $post]);
+        $this->fail('ModelResolutionException was not thrown.');
+    } catch (Throwable $e) {
+        // If it's wrapped in a ViewException, get the inner exception
+        $actual = $e instanceof ViewException ? $e->getPrevious() : $e;
+
+        expect($actual)->toBeInstanceOf(ModelResolutionException::class)
+            ->and($actual->getMessage())->toBe('Target model must be saved before attaching media.');
+    }
+});
+
+it('throws ModelResolutionException if model does not implement HasMedia', function () {
+    $user = new User;
+
+    try {
+        Livewire::test(MediaUploader::class, ['for' => $user]);
+        $this->fail('ModelResolutionException was not thrown.');
+    } catch (Throwable $e) {
+        // If it's wrapped in a ViewException, get the inner exception
+        $actual = $e instanceof ViewException ? $e->getPrevious() : $e;
+
+        expect($actual)->toBeInstanceOf(ModelResolutionException::class);
+    }
 });


### PR DESCRIPTION
- Refactor name conflict logic to use NameConflictStrategy Enum
- Replace abort() calls with custom ModelResolutionException
- Add model_namespaces configuration for flexible model resolution
- Expand test suite to cover new exceptions and skip strategy
- Update README and CHANGELOG to reflect v0.4.0 changes